### PR TITLE
[Fix] new layer-manager repo link

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "^4.17.1",
     "express-favicon": "^2.0.1",
     "foundation-sites": "^6.5.3",
-    "layer-manager": "https://github.com/alexmalinin/layer-manager.git#feature/fit-map-to-layer",
+    "layer-manager": "https://github.com/ConservationInternational/resilienceatlas-layermanager.git",
     "leaflet": "^1.4.0",
     "leaflet-active-area": "^1.1.0",
     "leaflet.pm": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6824,9 +6824,9 @@ layer-manager@^1.10.0:
     supercluster "^4.1.1"
     wri-json-api-serializer "^1.0.1"
 
-"layer-manager@https://github.com/alexmalinin/layer-manager.git#feature/fit-map-to-layer":
+"layer-manager@https://github.com/ConservationInternational/resilienceatlas-layermanager.git":
   version "1.0.1-resilience"
-  resolved "https://github.com/alexmalinin/layer-manager.git#715cc42b8868b574d24db3acb21cd37558f3512b"
+  resolved "https://github.com/ConservationInternational/resilienceatlas-layermanager.git#7849ccb7db8c2c5a739183c2b8d86e9eece3e5cc"
   dependencies:
     axios "^0.18.0"
     lodash "^4.17.11"


### PR DESCRIPTION
## Ticket:
- https://www.pivotaltracker.com/story/show/166928260

## Result:
- changed link in `package.json` to new `layer-manager` repo