### PR TITLE
[Fix] paddd subdomain layers and header

### DIFF
--- a/src/state/modules/layers/selectors.js
+++ b/src/state/modules/layers/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
+import { denormalize } from 'normalizr';
 import { sortBy } from '@utilities';
 
-import { denormalize } from 'normalizr';
 import {
   getById as getGroupsById,
   getGroups,
@@ -80,7 +80,7 @@ export const getGrouped = () => {
       g_defaultActive,
     ) => {
       const isActive = getActiveFromDefaults(g_defaultActive);
-      if (!groups.length || !g_categories.length) {
+      if (!groups.length && !g_categories.length) {
         console.info('There aren`t groups setted.');
         return groups;
       }

--- a/src/state/modules/site/reducer.js
+++ b/src/state/modules/site/reducer.js
@@ -1,4 +1,3 @@
-import { subdomain } from '@utilities/helpers';
 import { createReducer } from '../../utils';
 import { LOAD } from './actions';
 
@@ -6,7 +5,7 @@ const initialState = {
   has_analysis: false,
   predictive_model: false,
   name: '',
-  subdomain,
+  subdomain: '',
   color: '#0089cc',
   header_theme: '',
   lat: NaN,

--- a/src/views/components/LayersList/LayersList.component.jsx
+++ b/src/views/components/LayersList/LayersList.component.jsx
@@ -3,8 +3,8 @@ import cx from 'classnames';
 import { connect } from 'react-redux';
 import Loader from '@shared/Loader';
 
-import { clickable } from '@utilities';
 import { toggle as toggleGroup } from '@modules/layer_groups';
+import { clickable } from '@utilities';
 
 import Layer from './Layer';
 import Basemaps from './Basemaps';

--- a/src/views/components/LayersList/LayersList.container.js
+++ b/src/views/components/LayersList/LayersList.container.js
@@ -1,4 +1,3 @@
-import { compose } from 'redux';
 import { connect } from 'react-redux';
 
 import { getGrouped } from '@modules/layers';
@@ -17,4 +16,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default compose(connect(mapStateToProps))(LayerList);
+export default connect(mapStateToProps)(LayerList);


### PR DESCRIPTION
## Ticket:
- https://www.pivotaltracker.com/story/show/166981265

## Result:
- fixed header flicking with colors (caused by subdomain received from `site_scope=paddd` was empty string)
- fixed paddd layers (caused by paddd has no subgroups)